### PR TITLE
Parse `[ ] task` lines in `todo` carry-over and `catchup`

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -116,6 +116,51 @@ def test_today_carries_from_latest_previous_note(
     assert fake_editor == [today_note]
 
 
+def test_today_carries_from_bare_checkbox_items(
+    runner: CliRunner,
+    isolated_home: dict[str, Path],
+    fake_editor: list[Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    notes_dir = isolated_home["home"] / "notes"
+    cfg_path = isolated_home["xdg"] / "todo" / "config.toml"
+    write_config(cfg_path, notes_dir=notes_dir, layout="year_month", carry_over_mode="auto")
+
+    config = Config(notes_dir=notes_dir, layout="year_month", carry_over_mode="auto")
+    prior_note = note_path_for_date(config, date(2026, 3, 5))
+    prior_note.parent.mkdir(parents=True, exist_ok=True)
+    prior_note.write_text(
+        """# 2026-03-05
+
+## first
+[ ] a
+[ ] b
+[ ] c
+
+## second
+[ ] d
+[x] e
+""",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(cli, "today_date", lambda: date(2026, 3, 7))
+
+    result = runner.invoke(cli.main, ["today"])
+
+    assert result.exit_code == 0
+    today_note = note_path_for_date(config, date(2026, 3, 7))
+    content = today_note.read_text(encoding="utf-8")
+
+    assert "## Carry-over from 2026-03-05" in content
+    assert "- [ ] a" in content
+    assert "- [ ] b" in content
+    assert "- [ ] c" in content
+    assert "- [ ] d" in content
+    assert "- [ ] e" not in content
+    assert fake_editor == [today_note]
+
+
 def test_today_preserves_section_context_across_multiple_carry_overs(
     runner: CliRunner,
     isolated_home: dict[str, Path],

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -34,6 +34,25 @@ def test_collect_unchecked_tasks_groups_by_h2_heading() -> None:
     }
 
 
+def test_collect_unchecked_tasks_accepts_bare_checkbox_lines() -> None:
+    markdown = """# 2026-03-06
+
+## Campus network
+[ ] Check switch room B
+[x] Done item
+
+## Storage
+- [ ] Validate snapshots
+"""
+
+    grouped = collect_unchecked_tasks(markdown)
+
+    assert grouped == {
+        "Campus network": ["Check switch room B"],
+        "Storage": ["Validate snapshots"],
+    }
+
+
 def test_collect_unchecked_tasks_handles_no_h2_with_general_bucket() -> None:
     markdown = """# 2026-03-06
 - [ ] Follow up with facilities

--- a/todocli/notes.py
+++ b/todocli/notes.py
@@ -7,7 +7,7 @@ from .config import Config
 
 H2_RE = re.compile(r"^\s*##\s+(?P<title>.+?)\s*$")
 H3_RE = re.compile(r"^\s*###\s+(?P<title>.+?)\s*$")
-CHECKBOX_RE = re.compile(r"^\s*[-*]\s+\[(?P<mark>[ xX])\]\s+(?P<body>.+?)\s*$")
+CHECKBOX_RE = re.compile(r"^\s*(?:[-*]\s+)?\[(?P<mark>[ xX])\]\s+(?P<body>.+?)\s*$")
 CARRY_OVER_PREFIX = "Carry-over from "
 CATCHUP_START_MARKER = "<!-- todo catchup start -->"
 CATCHUP_END_MARKER = "<!-- todo catchup end -->"


### PR DESCRIPTION
## What changed
* Update task parsing to accept both list-style checkboxes (`- [ ] task`, `* [ ] task`) and bare checkbox lines (`[ ] task`).
* Add parser regression test for bare checkbox lines.
* Add CLI regression test proving `todo today` carries unfinished tasks from a prior note written with bare checkbox lines.

## Why
* A manually written note using `[ ] task` lines did not carry over unfinished tasks.
* Supporting both common markdown checkbox styles avoids silent data loss in carry-over and `catchup`.

## How to test
### Automated
* `uv run --extra dev -- pytest -q`
* `gate`

### Manual
* Create `~/TODO/notes/YYYY/MM/YYYY-MM-DD.md` with sections containing bare lines like `[ ] a` and `[x] done`.
* Run `todo` on a later date.
* Confirm the new note contains carried tasks from `[ ] ...` lines and excludes `[x] ...` lines.
* Run `todo catchup --dry-run` and confirm the preview includes unresolved bare-checkbox tasks.

## Risk/comp notes
* Parsing is a bit broader; lines that match `[ ] text` now count as tasks even without a list marker.
* Generated output remains normalized to `- [ ] ...` format.

## Changelog fragment
* no
* Behavior is corrected in parsing; repo has no `scriv` setup and release notes cover user-facing changes.
