### PR TITLE
Add release fragment for `todo --version` metadata alignment

### DIFF
--- a/changelog.d/20260307_235000_sderev.md
+++ b/changelog.d/20260307_235000_sderev.md
@@ -1,0 +1,3 @@
+Fixed
+-----
+* Align package metadata version with release tags so `todo --version` reports the current release version.


### PR DESCRIPTION
## What changed
* Add `changelog.d/20260307_235000_sderev.md` under `Fixed`.
* Record the user-facing fix that `todo --version` should match release metadata.

## Why
* `v0.1.2` was published while `project.version` remained `0.1.0`, so `todo --version` output was wrong.
* This fragment is needed before running the release-prep workflow for the next tag.

## How to test
### Automated
* `gate`

### Manual
* Run `uv run --extra dev scriv print` and confirm a `Fixed` entry appears for version alignment.
* Confirm the new fragment file exists under `changelog.d/`.

## Risk/comp notes
* No runtime code path changes in this PR.

## Changelog fragment
* yes
* Adds a `Fixed` fragment for release version output alignment.
