### PR TITLE
Sync `project.version` and release-prep version bump

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to prepare (e.g., 0.1.2)"
+        description: "Version to prepare (e.g., 0.1.3)"
         required: true
         type: string
 
@@ -28,6 +28,13 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
+
+      - name: Set project version
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          uv version "$VERSION" --frozen
 
       - name: Collect changelog fragments
         env:
@@ -55,6 +62,6 @@ jobs:
           fi
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add CHANGELOG.md changelog.d/
+          git add pyproject.toml CHANGELOG.md changelog.d/
           git commit -m "Collect changelog for v${VERSION}"
           git push

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "todo-daily-notes"
-version = "0.1.0"
+version = "0.1.3"
 description = "Create and open daily markdown notes from the terminal"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -286,7 +286,7 @@ wheels = [
 
 [[package]]
 name = "todo-daily-notes"
-version = "0.1.0"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## What changed
* Set `project.version` to `0.1.3` in `pyproject.toml`.
* Update local lock metadata to `0.1.3` in `uv.lock`.
* Update `.github/workflows/prepare-release.yml` to run `uv version "$VERSION" --frozen` and include `pyproject.toml` in the release-prep commit.

## Why
* `v0.1.2` was tagged while metadata stayed at `0.1.0`, so `todo --version` output was wrong.
* Release prep should bump package metadata automatically to avoid this mismatch.

## How to test
### Automated
* `gate`

### Manual
* Run `./todo --version` and confirm it prints `todo, version 0.1.3`.
* Inspect `.github/workflows/prepare-release.yml` and confirm it sets the version before `scriv collect`.

## Risk/comp notes
* No behavior change besides reported version metadata and release-prep automation.

## Changelog fragment
* no
* This aligns release metadata/process; the user-facing note is already in `CHANGELOG.md` under `0.1.3`.
