### PR TITLE
Add `bullet_marker` setting for generated task lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ If `XDG_CONFIG_HOME` is set, `todo` uses
 notes_dir = "~/TODO/notes"
 layout = "year_month"
 carry_over_mode = "auto"
+bullet_marker = "*"
 ```
 
 | Key                | Values                      | Effect                                         |
@@ -89,6 +90,7 @@ carry_over_mode = "auto"
 | `notes_dir`        | any path                    | Base folder for notes. Stored as absolute path. |
 | `layout`           | `year_month`, `flat`        | `year_month` stores notes in `YYYY/MM/`.        |
 | `carry_over_mode`  | `auto`, `prompt`, `off`     | See [Carry-over](#carry-over) above.            |
+| `bullet_marker`    | `*`, `-`                    | List marker used for new checkbox items.        |
 
 ## Shell completion
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -40,13 +40,21 @@ def fake_editor(monkeypatch: pytest.MonkeyPatch) -> list[Path]:
     return opened
 
 
-def write_config(path: Path, *, notes_dir: Path, layout: str, carry_over_mode: str) -> None:
+def write_config(
+    path: Path,
+    *,
+    notes_dir: Path,
+    layout: str,
+    carry_over_mode: str,
+    bullet_marker: str = "*",
+) -> None:
     write_app_config(
         path,
         Config(
             notes_dir=notes_dir,
             layout=layout,
             carry_over_mode=carry_over_mode,
+            bullet_marker=bullet_marker,
         ),
     )
 
@@ -110,8 +118,8 @@ def test_today_carries_from_latest_previous_note(
     content = today_note.read_text(encoding="utf-8")
 
     assert "## Carry-over from 2026-03-06" in content
-    assert "- [ ] Finish change plan" in content
-    assert "- [ ] Reply to NOC" in content
+    assert "* [ ] Finish change plan" in content
+    assert "* [ ] Reply to NOC" in content
     assert "Announce completion" not in content
     assert "stale task" not in content
     assert fake_editor == [today_note]
@@ -154,11 +162,11 @@ def test_today_carries_from_bare_checkbox_items(
     content = today_note.read_text(encoding="utf-8")
 
     assert "## Carry-over from 2026-03-05" in content
-    assert "- [ ] a" in content
-    assert "- [ ] b" in content
-    assert "- [ ] c" in content
-    assert "- [ ] d" in content
-    assert "- [ ] e" not in content
+    assert "* [ ] a" in content
+    assert "* [ ] b" in content
+    assert "* [ ] c" in content
+    assert "* [ ] d" in content
+    assert "* [ ] e" not in content
     assert fake_editor == [today_note]
 
 
@@ -286,7 +294,7 @@ def test_prompt_mode_carries_when_confirmed(
     today_note = note_path_for_date(config, date(2026, 3, 9))
     content = today_note.read_text(encoding="utf-8")
     assert "Carry-over" in content
-    assert "- [ ] Pending task" in content
+    assert "* [ ] Pending task" in content
     assert fake_editor == [today_note]
 
 
@@ -463,6 +471,7 @@ def test_config_command_shows_defaults_without_file(
     assert str(isolated_home["home"] / "TODO" / "notes") in result.output
     assert "layout: year_month" in result.output
     assert "carry_over_mode: auto" in result.output
+    assert "bullet_marker: *" in result.output
 
 
 def test_repo_wrapper_runs_without_traceback(tmp_path: Path) -> None:
@@ -575,7 +584,7 @@ def test_catchup_dry_run_prints_grouped_preview_without_creating_today_note(
     assert "Target note:" in result.output
     assert "Would import:" in result.output
     assert "### Tickets" in result.output
-    assert "- [ ] Reply to NOC" in result.output
+    assert "* [ ] Reply to NOC" in result.output
     assert "Update package index" not in result.output
     assert "Scanned files: 2" in result.output
     assert "Unresolved tasks: 1" in result.output
@@ -719,7 +728,7 @@ Manual note
     assert "stale task" not in content
     assert "Manual note" in content
     assert "### Tickets" in content
-    assert "- [ ] Reply to NOC" in content
+    assert "* [ ] Reply to NOC" in content
     assert "Update package index" not in content
     assert fake_editor == [today_note]
     assert "Updated:" in result.output
@@ -788,3 +797,222 @@ Manual note
     assert "Manual note" in content
     assert fake_editor == [today_note]
     assert "Unresolved tasks: 0" in result.output
+
+
+# ---------------------------------------------------------------------------
+# bullet_marker tests
+# ---------------------------------------------------------------------------
+
+
+def test_config_command_shows_configured_dash_bullet_marker(
+    runner: CliRunner,
+    isolated_home: dict[str, Path],
+) -> None:
+    notes_dir = isolated_home["home"] / "notes"
+    cfg_path = isolated_home["xdg"] / "todo" / "config.toml"
+    write_config(
+        cfg_path,
+        notes_dir=notes_dir,
+        layout="year_month",
+        carry_over_mode="auto",
+        bullet_marker="-",
+    )
+
+    result = runner.invoke(cli.main, ["config"])
+
+    assert result.exit_code == 0
+    assert "bullet_marker: -" in result.output
+
+
+def test_init_writes_dash_bullet_marker(
+    runner: CliRunner,
+    isolated_home: dict[str, Path],
+    fake_editor: list[Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(cli, "today_date", lambda: date(2026, 3, 9))
+
+    init_result = runner.invoke(cli.main, ["init", "--bullet-marker", "-"])
+
+    assert init_result.exit_code == 0
+    cfg_path = isolated_home["xdg"] / "todo" / "config.toml"
+    assert 'bullet_marker = "-"' in cfg_path.read_text(encoding="utf-8")
+
+    config_result = runner.invoke(cli.main, ["config"])
+    assert "bullet_marker: -" in config_result.output
+
+
+def test_init_rejects_invalid_bullet_marker_choice(
+    runner: CliRunner,
+    isolated_home: dict[str, Path],
+) -> None:
+    result = runner.invoke(cli.main, ["init", "--bullet-marker", "+"])
+
+    assert result.exit_code != 0
+    assert "Invalid value for '--bullet-marker'" in result.output
+
+
+def test_today_carries_from_latest_previous_note_with_dash_bullet_marker(
+    runner: CliRunner,
+    isolated_home: dict[str, Path],
+    fake_editor: list[Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    notes_dir = isolated_home["home"] / "notes"
+    cfg_path = isolated_home["xdg"] / "todo" / "config.toml"
+    write_config(
+        cfg_path,
+        notes_dir=notes_dir,
+        layout="year_month",
+        carry_over_mode="auto",
+        bullet_marker="-",
+    )
+
+    config = Config(
+        notes_dir=notes_dir, layout="year_month", carry_over_mode="auto", bullet_marker="-"
+    )
+    friday_note = note_path_for_date(config, date(2026, 3, 6))
+    friday_note.parent.mkdir(parents=True, exist_ok=True)
+    friday_note.write_text(
+        """# 2026-03-06
+
+## Tickets
+- [ ] Reply to NOC
+- [X] Closed task
+""",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(cli, "today_date", lambda: date(2026, 3, 9))
+
+    result = runner.invoke(cli.main, ["today"])
+
+    assert result.exit_code == 0
+    today_note = note_path_for_date(config, date(2026, 3, 9))
+    content = today_note.read_text(encoding="utf-8")
+    assert "- [ ] Reply to NOC" in content
+    assert "Closed task" not in content
+    assert fake_editor == [today_note]
+
+
+def test_prompt_mode_carries_when_confirmed_with_dash_bullet_marker(
+    runner: CliRunner,
+    isolated_home: dict[str, Path],
+    fake_editor: list[Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    notes_dir = isolated_home["home"] / "notes"
+    cfg_path = isolated_home["xdg"] / "todo" / "config.toml"
+    write_config(
+        cfg_path,
+        notes_dir=notes_dir,
+        layout="year_month",
+        carry_over_mode="prompt",
+        bullet_marker="-",
+    )
+
+    config = Config(
+        notes_dir=notes_dir, layout="year_month", carry_over_mode="prompt", bullet_marker="-"
+    )
+    friday_note = note_path_for_date(config, date(2026, 3, 6))
+    friday_note.parent.mkdir(parents=True, exist_ok=True)
+    friday_note.write_text("# 2026-03-06\n\n## Ops\n- [ ] Pending task\n", encoding="utf-8")
+
+    monkeypatch.setattr(cli, "today_date", lambda: date(2026, 3, 9))
+    monkeypatch.setattr(cli.click, "confirm", lambda *args, **kwargs: True)
+
+    result = runner.invoke(cli.main, ["today"])
+
+    assert result.exit_code == 0
+    today_note = note_path_for_date(config, date(2026, 3, 9))
+    content = today_note.read_text(encoding="utf-8")
+    assert "Carry-over" in content
+    assert "- [ ] Pending task" in content
+    assert fake_editor == [today_note]
+
+
+def test_catchup_dry_run_uses_dash_bullet_marker(
+    runner: CliRunner,
+    isolated_home: dict[str, Path],
+    fake_editor: list[Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    notes_dir = isolated_home["home"] / "notes"
+    cfg_path = isolated_home["xdg"] / "todo" / "config.toml"
+    write_config(
+        cfg_path,
+        notes_dir=notes_dir,
+        layout="year_month",
+        carry_over_mode="auto",
+        bullet_marker="-",
+    )
+
+    config = Config(
+        notes_dir=notes_dir, layout="year_month", carry_over_mode="auto", bullet_marker="-"
+    )
+    march_6 = note_path_for_date(config, date(2026, 3, 6))
+    march_6.parent.mkdir(parents=True, exist_ok=True)
+    march_6.write_text(
+        """# 2026-03-06
+
+## Tickets
+- [ ] Reply to NOC
+""",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(cli, "today_date", lambda: date(2026, 3, 9))
+
+    result = runner.invoke(cli.main, ["catchup", "--since", "2026-03-06", "--dry-run"])
+
+    assert result.exit_code == 0
+    today_note = note_path_for_date(config, date(2026, 3, 9))
+    assert not today_note.exists()
+    assert "- [ ] Reply to NOC" in result.output
+    assert fake_editor == []
+
+
+def test_catchup_upserts_managed_section_with_dash_bullet_marker(
+    runner: CliRunner,
+    isolated_home: dict[str, Path],
+    fake_editor: list[Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    notes_dir = isolated_home["home"] / "notes"
+    cfg_path = isolated_home["xdg"] / "todo" / "config.toml"
+    write_config(
+        cfg_path,
+        notes_dir=notes_dir,
+        layout="year_month",
+        carry_over_mode="auto",
+        bullet_marker="-",
+    )
+
+    config = Config(
+        notes_dir=notes_dir, layout="year_month", carry_over_mode="auto", bullet_marker="-"
+    )
+    march_6 = note_path_for_date(config, date(2026, 3, 6))
+    march_6.parent.mkdir(parents=True, exist_ok=True)
+    march_6.write_text(
+        """# 2026-03-06
+
+## Tickets
+- [ ] Reply to NOC
+""",
+        encoding="utf-8",
+    )
+
+    today_note = note_path_for_date(config, date(2026, 3, 9))
+    today_note.parent.mkdir(parents=True, exist_ok=True)
+    today_note.write_text("# 2026-03-09\n\nManual note\n", encoding="utf-8")
+
+    monkeypatch.setattr(cli, "today_date", lambda: date(2026, 3, 9))
+
+    result = runner.invoke(cli.main, ["catchup", "--since", "2026-03-06"])
+
+    assert result.exit_code == 0
+    content = today_note.read_text(encoding="utf-8")
+    assert "- [ ] Reply to NOC" in content
+    assert "* [ ] Reply to NOC" not in content
+    assert "Manual note" in content
+    assert fake_editor == [today_note]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -27,6 +27,7 @@ def test_load_config_without_create_returns_defaults(
     assert state.config.notes_dir == isolated_home["home"] / "TODO" / "notes"
     assert state.config.layout == "year_month"
     assert state.config.carry_over_mode == "auto"
+    assert state.config.bullet_marker == "*"
 
 
 def test_load_config_rejects_invalid_layout(
@@ -54,6 +55,21 @@ def test_load_config_rejects_invalid_carry_over_mode(
     )
 
     with pytest.raises(ValueError, match="Invalid `carry_over_mode` value"):
+        load_config()
+
+
+def test_load_config_rejects_invalid_bullet_marker(
+    isolated_home: dict[str, Path],
+) -> None:
+    cfg_path = config_path()
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    cfg_path.write_text(
+        'notes_dir = "~/TODO/notes"\nlayout = "year_month"\ncarry_over_mode = "auto"\n'
+        'bullet_marker = "+"\n',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="Invalid `bullet_marker` value"):
         load_config()
 
 

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -168,11 +168,12 @@ def test_render_carry_over_keeps_section_context() -> None:
             "Campus network": ["Check switch room B"],
             "Storage": ["Validate snapshots"],
         },
+        bullet_marker="*",
     )
 
     assert "## Carry-over from 2026-03-06" in rendered
     assert "### Campus network" in rendered
-    assert "- [ ] Check switch room B" in rendered
+    assert "* [ ] Check switch room B" in rendered
     assert "### Storage" in rendered
 
 
@@ -346,10 +347,13 @@ still here
 
     updated = replace_catchup_block(
         original,
-        render_catchup_block({"Ops": ["New task"], "Tickets": ["Reply to NOC"]}),
+        render_catchup_block(
+            {"Ops": ["New task"], "Tickets": ["Reply to NOC"]},
+            bullet_marker="*",
+        ),
     )
 
     assert updated.count("<!-- todo catchup start -->") == 1
     assert "Old task" not in updated
-    assert "- [ ] New task" in updated
+    assert "* [ ] New task" in updated
     assert "## Later\nstill here\n" in updated

--- a/todocli/cli.py
+++ b/todocli/cli.py
@@ -6,8 +6,10 @@ import click
 from click_default_group import DefaultGroup
 
 from .config import (
+    ALLOWED_BULLET_MARKERS,
     ALLOWED_CARRY_OVER_MODES,
     ALLOWED_LAYOUTS,
+    DEFAULT_BULLET_MARKER,
     DEFAULT_CARRY_OVER_MODE,
     DEFAULT_LAYOUT,
     DEFAULT_NOTES_DIR,
@@ -102,15 +104,20 @@ def build_carry_over_section(config: Config, note_date: date) -> str:
         ):
             return ""
 
-    return render_carry_over(prior_note.note_date, grouped_tasks)
+    return render_carry_over(
+        prior_note.note_date,
+        grouped_tasks,
+        bullet_marker=config.bullet_marker,
+    )
 
 
-def format_catchup_preview(grouped_tasks: dict[str, list[str]]) -> str:
+def format_catchup_preview(grouped_tasks: dict[str, list[str]], *, bullet_marker: str) -> str:
     lines = ["Would import:"]
     for section, tasks in grouped_tasks.items():
         lines.append(f"### {section}")
+        lines.append("")
         for task in tasks:
-            lines.append(f"- [ ] {task}")
+            lines.append(f"{bullet_marker} [ ] {task}")
         lines.append("")
 
     return "\n".join(lines).rstrip()
@@ -146,7 +153,11 @@ def create_or_update_catchup_note(
     original_content = (
         note_path.read_text(encoding="utf-8") if existed else render_note_header(note_date) + "\n"
     )
-    catchup_block = render_catchup_block(grouped_tasks) if grouped_tasks else None
+    catchup_block = (
+        render_catchup_block(grouped_tasks, bullet_marker=config.bullet_marker)
+        if grouped_tasks
+        else None
+    )
     updated_content = replace_catchup_block(original_content, catchup_block)
 
     if not existed or updated_content != original_content:
@@ -190,11 +201,19 @@ def main() -> None:
     show_default=True,
     help="How to handle unfinished tasks from the previous note.",
 )
+@click.option(
+    "--bullet-marker",
+    type=click.Choice(ALLOWED_BULLET_MARKERS),
+    default=DEFAULT_BULLET_MARKER,
+    show_default=True,
+    help="Bullet marker used for checkbox list items.",
+)
 @click.option("--force", is_flag=True, help="Overwrite an existing config file.")
 def init(
     notes_dir: Path | None,
     layout: str,
     carry_over_mode: str,
+    bullet_marker: str,
     force: bool,
 ) -> None:
     """Create `~/.config/todo/config.toml` (or `$XDG_CONFIG_HOME/todo/config.toml` if set)."""
@@ -212,6 +231,7 @@ def init(
         notes_dir=resolved_notes_dir,
         layout=layout,
         carry_over_mode=carry_over_mode,
+        bullet_marker=bullet_marker,
     )
     write_config(cfg_path, config)
 
@@ -266,6 +286,7 @@ def show_config() -> None:
     click.echo(f"{styled_label('notes_dir')}: {state.config.notes_dir}")
     click.echo(f"{styled_label('layout')}: {state.config.layout}")
     click.echo(f"{styled_label('carry_over_mode')}: {state.config.carry_over_mode}")
+    click.echo(f"{styled_label('bullet_marker')}: {state.config.bullet_marker}")
 
 
 @main.command()
@@ -312,7 +333,12 @@ def catchup(since: datetime | None, dry_run: bool, yes: bool) -> None:
             f"{styled_label('Target note')}: {note_path_for_date(state.config, target_date)}"
         )
         if scan_result.grouped_tasks:
-            click.echo(format_catchup_preview(scan_result.grouped_tasks))
+            click.echo(
+                format_catchup_preview(
+                    scan_result.grouped_tasks,
+                    bullet_marker=state.config.bullet_marker,
+                )
+            )
         else:
             click.echo(f"{styled_label('Would import')}: nothing")
 

--- a/todocli/config.py
+++ b/todocli/config.py
@@ -8,8 +8,10 @@ APP_NAME = "todo"
 DEFAULT_NOTES_DIR = "~/TODO/notes"
 DEFAULT_LAYOUT = "year_month"
 DEFAULT_CARRY_OVER_MODE = "auto"
+DEFAULT_BULLET_MARKER = "*"
 ALLOWED_LAYOUTS = {"year_month", "flat"}
 ALLOWED_CARRY_OVER_MODES = {"auto", "prompt", "off"}
+ALLOWED_BULLET_MARKERS: tuple[str, ...] = ("*", "-")
 
 
 @dataclass(frozen=True, slots=True)
@@ -17,6 +19,7 @@ class Config:
     notes_dir: Path
     layout: str = DEFAULT_LAYOUT
     carry_over_mode: str = DEFAULT_CARRY_OVER_MODE
+    bullet_marker: str = DEFAULT_BULLET_MARKER
 
 
 @dataclass(frozen=True, slots=True)
@@ -47,6 +50,7 @@ def write_config(path: Path, config: Config) -> None:
         f"notes_dir = {json.dumps(config.notes_dir.as_posix())}\n"
         f"layout = {json.dumps(config.layout)}\n"
         f"carry_over_mode = {json.dumps(config.carry_over_mode)}\n"
+        f"bullet_marker = {json.dumps(config.bullet_marker)}\n"
     )
     path.write_text(content, encoding="utf-8")
 
@@ -79,6 +83,13 @@ def _validate_carry_over_mode(value: str) -> str:
     return value
 
 
+def _validate_bullet_marker(value: str) -> str:
+    if value not in ALLOWED_BULLET_MARKERS:
+        allowed = ", ".join(ALLOWED_BULLET_MARKERS)
+        raise ValueError(f"Invalid `bullet_marker` value: {value!r}. Expected one of: {allowed}.")
+    return value
+
+
 def load_config(create_if_missing: bool = True) -> ConfigState:
     path = config_path()
     if not path.exists():
@@ -98,6 +109,12 @@ def load_config(create_if_missing: bool = True) -> ConfigState:
     carry_over_mode = _validate_carry_over_mode(
         data.get("carry_over_mode", DEFAULT_CARRY_OVER_MODE)
     )
+    bullet_marker = _validate_bullet_marker(data.get("bullet_marker", DEFAULT_BULLET_MARKER))
 
-    config = Config(notes_dir=notes_dir, layout=layout, carry_over_mode=carry_over_mode)
+    config = Config(
+        notes_dir=notes_dir,
+        layout=layout,
+        carry_over_mode=carry_over_mode,
+        bullet_marker=bullet_marker,
+    )
     return ConfigState(config=config, path=path, created=False)

--- a/todocli/notes.py
+++ b/todocli/notes.py
@@ -197,23 +197,30 @@ def scan_catchup_tasks(
     return scan_catchup_tasks_from_notes(notes)
 
 
-def render_carry_over(previous_date: date, grouped_tasks: dict[str, list[str]]) -> str:
+def render_carry_over(
+    previous_date: date,
+    grouped_tasks: dict[str, list[str]],
+    *,
+    bullet_marker: str,
+) -> str:
     lines = [f"## Carry-over from {previous_date.isoformat()}", ""]
     for section, tasks in grouped_tasks.items():
         lines.append(f"### {section}")
+        lines.append("")
         for task in tasks:
-            lines.append(f"- [ ] {task}")
+            lines.append(f"{bullet_marker} [ ] {task}")
         lines.append("")
 
     return "\n".join(lines).rstrip() + "\n"
 
 
-def render_catchup_block(grouped_tasks: dict[str, list[str]]) -> str:
+def render_catchup_block(grouped_tasks: dict[str, list[str]], *, bullet_marker: str) -> str:
     lines = [CATCHUP_START_MARKER, "## Catch-up", ""]
     for section, tasks in grouped_tasks.items():
         lines.append(f"### {section}")
+        lines.append("")
         for task in tasks:
-            lines.append(f"- [ ] {task}")
+            lines.append(f"{bullet_marker} [ ] {task}")
         lines.append("")
     lines.append(CATCHUP_END_MARKER)
     return "\n".join(lines).rstrip() + "\n"


### PR DESCRIPTION
What changed
* Add `bullet_marker` config handling, CLI option, and config output.
* Render carry-over and catch-up tasks with a blank line after section headings and the configured marker.
* Update tests and README for `bullet_marker`.

Why
Let users choose `*` or `-` for generated task lists while keeping valid Markdown spacing.

How to test
* `uv run --extra dev pytest`
* Manual: run `todo init --bullet-marker "*"`, create a prior note with unchecked tasks, run `todo today` and `todo catchup --dry-run`, and confirm `* [ ]` output appears with a blank line after section headings.

Risk/comp notes
* Low; affects formatting of generated sections.

Changelog fragment: no (requested not to add).